### PR TITLE
Teal Expose Support

### DIFF
--- a/CodeGenWriter.cs
+++ b/CodeGenWriter.cs
@@ -1,0 +1,205 @@
+﻿using CppAst;
+using Scriban;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace LuaExpose
+{
+    public abstract class CodeGenWriter
+    {
+        public class LuaUserType
+        {
+            public LuaUserType()
+            {
+            }
+
+            private ICppDeclaration originalElement;
+            private string originLocation;
+
+            public ICppDeclaration OriginalElement { get => originalElement; set => originalElement = value; }
+            public string OriginLocation { get => originLocation; set => originLocation = value; }
+            public string TypeName { get => OriginalElement.GetName(); }
+            public string TypeNameLower => TypeName.ToLower();
+
+            public bool IsNamespace => originalElement is CppNamespace;
+            public bool IsClass => originalElement is CppClass;
+
+            public List<CppFunction> NormalFunctions => this.GetNormalFunctions();
+            public List<CppEnum> Enums => this.GetEnums();
+
+            public List<CppClass> Classes => this.GetClasses();
+            public CppNamespace globalNameSpace;
+        }
+
+        public class LuaUserTypeFile
+        {
+            public LuaUserTypeFile()
+            {
+                userTypes = new Dictionary<string, LuaUserType>();
+            }
+            public Dictionary<string, LuaUserType> userTypes;
+            public string path;
+        }
+
+        protected string template;
+        protected CppNamespace rootNamespace;
+        protected CppCompilation compiledCode;
+        protected Dictionary<string, LuaUserTypeFile> userTypeFiles;
+
+        public CodeGenWriter(CppCompilation compilation, string scrib)
+        {
+            template = scrib;
+            rootNamespace = compilation.Namespaces.Where(x => x.Name.Contains("siege")).FirstOrDefault();
+            compiledCode = compilation;
+            userTypeFiles = new Dictionary<string, LuaUserTypeFile>();
+        }
+
+        protected LuaUserTypeFile GetPathFile(string path)
+        {
+            LuaUserTypeFile file = null;
+            if (!userTypeFiles.TryGetValue(path, out file))
+                file = AddPathFile(path);
+
+            return file;
+        }
+
+        protected LuaUserTypeFile AddPathFile(string path)
+        {
+            if (!userTypeFiles.ContainsKey(path))
+            {
+                userTypeFiles[path] = new LuaUserTypeFile();
+                userTypeFiles[path].path = path;
+            }
+
+            return userTypeFiles[path];
+        }
+
+        protected void ParseClasses(CppClass inElement)
+        {
+            if (string.IsNullOrEmpty(inElement.Span.End.File)) return;
+
+            void AddFunction(string path)
+            {
+                var filePath = GetPathFile(path);
+                var xx = new LuaUserType();
+                xx.OriginalElement = inElement;
+                xx.OriginLocation = path;
+                filePath.userTypes[inElement.Name] = xx;
+            }
+
+            foreach (var a in inElement.Attributes)
+            {
+                if (a.Name.Contains("LUA_USERTYPE"))
+                {
+                    AddFunction(a.Span.End.File);
+                }
+            }
+        }
+
+        protected void ParseEnums(CppEnum inElement)
+        {
+            if (string.IsNullOrEmpty(inElement.Span.End.File)) return;
+
+            void AddFunction(string path, CppAttribute a)
+            {
+                var filePath = GetPathFile(path);
+                var name = (inElement?.Parent as ICppMember)?.Name;
+                if (!filePath.userTypes.ContainsKey(name))
+                {
+                    // we are in the right file but this is likely caused by the scope not being
+                    // where it should be so we need to find a new home for this, so we will use the
+                    // scope of the parent for the attribute ? 
+                    var newHome = new LuaUserType();
+                    var parentName = (a?.Parent as ICppMember).Name;
+                    newHome.OriginalElement = (a.Parent as ICppDeclaration);
+                    newHome.OriginLocation = path;
+                    filePath.userTypes[parentName] = newHome;
+                    name = parentName;
+                }
+            }
+
+            foreach (var a in inElement.Attributes)
+            {
+                if (a.Name == "LUA_USERTYPE_ENUM")
+                {
+                    AddFunction(a.Span.End.File, a);
+                }
+            }
+        }
+
+        public void ParseNamespace(CppNamespace inElement)
+        {
+            // we have found a NameSpace that has been marked with an attribute
+            if (inElement.Attributes.Count != 0)
+            {
+                foreach (var a in inElement.Attributes)
+                {
+                    if (a.Name == "LUA_USERTYPE_NAMESPACE")
+                    {
+                        var filePath = GetPathFile(a.Span.Start.File);
+
+                        if (!filePath.userTypes.ContainsKey(inElement.Name))
+                        {
+                            var x = new LuaUserType();
+                            x.OriginalElement = inElement;
+                            x.OriginLocation = filePath.path;
+                            filePath.userTypes[inElement.Name] = x;
+                        }
+                    }
+                }
+            }
+
+            foreach (var ns in inElement.Namespaces)
+            {
+                ParseNamespace(ns);
+            }
+
+            foreach (var c in inElement.Classes)
+            {
+                ParseClasses(c);
+            }
+
+            foreach (var f in inElement.Enums)
+            {
+                ParseEnums(f);
+            }
+        }
+        protected void WriteFileContent(string content, string newPath)
+        {
+            using (System.IO.StreamWriter file =
+                new System.IO.StreamWriter(newPath))
+            {
+                file.Write(content);
+            }
+        }
+
+        protected abstract string GetContentFromLuaUserFile(LuaUserTypeFile value, string fileName, bool isGame);
+
+        protected abstract string GetUsertypeFileName(string usertypeFile);
+
+        protected virtual void WriteAllFiles(string v, bool isGame)
+        {
+            foreach (var f in userTypeFiles)
+            {
+                var content = GetContentFromLuaUserFile(f.Value, Path.GetFileNameWithoutExtension(f.Key), isGame);
+                var newPath = Path.Combine(v, GetUsertypeFileName(f.Key));
+                WriteFileContent(content, newPath);
+            }
+        }
+
+        public void Run(string outLocation, bool isGame)
+        {
+            Console.WriteLine($"Writing files to {outLocation}");
+
+            Directory.CreateDirectory(outLocation);
+
+            ParseNamespace(rootNamespace);
+            WriteAllFiles(outLocation, isGame);
+        }
+
+    }
+}

--- a/LuaCodeGenWriter.cs
+++ b/LuaCodeGenWriter.cs
@@ -9,41 +9,8 @@ using System.Text;
 
 namespace LuaExpose
 {
-    public class LuaCodeGenWriter
+    public class LuaCodeGenWriter : CodeGenWriter
     {
-        public class LuaUserType
-        {
-            public LuaUserType()
-            {
-            }
-
-            private ICppDeclaration originalElement;
-            private string originLocation;
-
-            public ICppDeclaration OriginalElement { get => originalElement; set => originalElement = value; }
-            public string OriginLocation { get => originLocation; set => originLocation = value; }
-            public string TypeName { get => OriginalElement.GetName(); }
-            public string TypeNameLower => TypeName.ToLower();
-
-            public bool IsNamespace => originalElement is CppNamespace;
-            public bool IsClass => originalElement is CppClass;
-
-            public List<CppFunction> NormalFunctions => this.GetNormalFunctions();
-            public List<CppEnum> Enums => this.GetEnums();
-
-            public List<CppClass> Classes => this.GetClasses();
-            public CppNamespace globalNameSpace;
-        }
-
-        public class LuaUserTypeFile
-        {
-            public LuaUserTypeFile()
-            {
-                userTypes = new Dictionary<string, LuaUserType>();
-            }
-            public Dictionary<string, LuaUserType> userTypes;
-            public string path;
-        }
 
         readonly List<string> globalHeaders = new List<string>
         {
@@ -59,129 +26,8 @@ namespace LuaExpose
             @"#include ""LuaUsertypes.h""",
         };
 
-        string template;
-        CppNamespace rootNamespace;
-        CppCompilation compiledCode;
-        Dictionary<string, LuaUserTypeFile> userTypeFiles;
-
-        public LuaCodeGenWriter(CppCompilation compilation, string scrib)
-        {
-            rootNamespace = compilation.Namespaces.Where(x => x.Name.Contains("siege")).FirstOrDefault();
-            compiledCode = compilation;
-            userTypeFiles = new Dictionary<string, LuaUserTypeFile>();
-            template = scrib;
-        }
-
-        LuaUserTypeFile GetPathFile(string path)
-        {
-            LuaUserTypeFile file = null;
-            if (!userTypeFiles.TryGetValue(path, out file))
-                file = AddPathFile(path);
-
-            return file;
-        }
-
-        LuaUserTypeFile AddPathFile(string path)
-        {
-            if (!userTypeFiles.ContainsKey(path))
-            {
-                userTypeFiles[path] = new LuaUserTypeFile();
-                userTypeFiles[path].path = path;
-            }
-
-            return userTypeFiles[path];
-        }
-
-        void ParseClasses(CppClass inElement)
-        {
-            if (string.IsNullOrEmpty(inElement.Span.End.File)) return;
-
-            void AddFunction(string path)
-            {
-                var filePath = GetPathFile(path);
-                var xx = new LuaUserType();
-                xx.OriginalElement = inElement;
-                xx.OriginLocation = path;
-                filePath.userTypes[inElement.Name] = xx;
-            }
-
-            foreach (var a in inElement.Attributes)
-            {
-                if (a.Name.Contains("LUA_USERTYPE"))
-                {
-                    AddFunction(a.Span.End.File);
-                }
-            }
-        }
-
-        void ParseEnums(CppEnum inElement)
-        {
-            if (string.IsNullOrEmpty(inElement.Span.End.File)) return;
-
-            void AddFunction(string path, CppAttribute a)
-            {
-                var filePath = GetPathFile(path);
-                var name = (inElement?.Parent as ICppMember)?.Name;
-                if (!filePath.userTypes.ContainsKey(name))
-                {
-                    // we are in the right file but this is likely caused by the scope not being
-                    // where it should be so we need to find a new home for this, so we will use the
-                    // scope of the parent for the attribute ? 
-                    var newHome = new LuaUserType();
-                    var parentName = (a?.Parent as ICppMember).Name;
-                    newHome.OriginalElement = (a.Parent as ICppDeclaration);
-                    newHome.OriginLocation = path;
-                    filePath.userTypes[parentName] = newHome;
-                    name = parentName;
-                }
-            }
-
-            foreach (var a in inElement.Attributes)
-            {
-                if (a.Name == "LUA_USERTYPE_ENUM")
-                {
-                    AddFunction(a.Span.End.File, a);
-                }
-            }
-        }
-
-        void ParseNamespace(CppNamespace inElement)
-        {
-            // we have found a NameSpace that has been marked with an attribute
-            if (inElement.Attributes.Count != 0)
-            {
-                foreach (var a in inElement.Attributes)
-                {
-                    if (a.Name == "LUA_USERTYPE_NAMESPACE")
-                    {
-                        var filePath = GetPathFile(a.Span.Start.File);
-
-                        if (!filePath.userTypes.ContainsKey(inElement.Name))
-                        {
-                            var x = new LuaUserType();
-                            x.OriginalElement = inElement;
-                            x.OriginLocation = filePath.path;
-                            filePath.userTypes[inElement.Name] = x;
-                        }
-                    }
-                }
-            }
-
-            foreach (var ns in inElement.Namespaces)
-            {
-                ParseNamespace(ns);
-            }
-
-            foreach (var c in inElement.Classes)
-            {
-                ParseClasses(c);
-            }
-
-            foreach (var f in inElement.Enums)
-            {
-                ParseEnums(f);
-            }
-        }
+        public LuaCodeGenWriter(CppCompilation compilation, string scrib) : base(compilation, scrib)
+        { }
 
         public string GenerateNamespaceSetup(LuaUserType lu)
         {            
@@ -786,7 +632,7 @@ namespace LuaExpose
             return currentOutput.ToString();
         }
 
-        string GetContentFromLuaUserFile(LuaUserTypeFile value, string fileName, bool isGame)
+        protected override string GetContentFromLuaUserFile(LuaUserTypeFile value, string fileName, bool isGame)
         {
             ConcurrentQueue<string> includeFiles = new ConcurrentQueue<string>(isGame ? globalGameHeaders : globalHeaders);
             List<string> usings = new List<string>();
@@ -863,33 +709,15 @@ namespace LuaExpose
             return scribe.Render(new { Includes = includes.Distinct(), Ltype = fileName.FirstCharToUpper(), Namespaces = namespaces, Classes = classes, Enums = enums, Usings = usings });
         }
 
-        void WriteAllFiles(string v, bool isGame)
+        protected override string GetUsertypeFileName(string usertypeFile)
         {
-            foreach (var f in userTypeFiles)
-            {
-                var newFileName = $"LuaUsertypes{Path.GetFileNameWithoutExtension(f.Key).FirstCharToUpper()}.cpp";
-                var newPath = Path.Combine(v, newFileName);
-
-                using (System.IO.StreamWriter file =
-                    new System.IO.StreamWriter(newPath))
-                {
-
-                    var content = GetContentFromLuaUserFile(f.Value, Path.GetFileNameWithoutExtension(f.Key), isGame);
-                    file.Write(content);
-                }
-            }
-
-            WriteLuaUserTypeFile(v, userTypeFiles, isGame);
+            return $"LuaUsertypes{Path.GetFileNameWithoutExtension(usertypeFile).FirstCharToUpper()}.cpp";
         }
 
-
-        private void WriteFileContent(string content, string newPath)
+        protected override void WriteAllFiles(string v, bool isGame)
         {
-            using (System.IO.StreamWriter file =
-                new System.IO.StreamWriter(newPath))
-            {
-                file.Write(content);
-            }
+            base.WriteAllFiles(v, isGame);
+            WriteLuaUserTypeFile(v, userTypeFiles, isGame);
         }
 
         private void WriteLuaUserTypeFile(string v, Dictionary<string, LuaUserTypeFile> userTypeFiles, bool isGame)
@@ -992,16 +820,6 @@ REPLACEMEWITHTEXT
             }
 
             WriteFileContent(content, newPath);
-        }
-
-        public void Run(string outLocation, bool isGame)
-        {
-            Console.WriteLine($"Writing files to {outLocation}");
-
-            Directory.CreateDirectory(outLocation);
-
-            ParseNamespace(rootNamespace);
-            WriteAllFiles(outLocation, isGame);
         }
     }
 }

--- a/TealCodeGenWriter.cs
+++ b/TealCodeGenWriter.cs
@@ -1,0 +1,201 @@
+﻿using CppAst;
+using Scriban;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LuaExpose
+{
+    public class TealCodeGenWriter : CodeGenWriter
+    {
+        public class TealVariable
+        {
+            public string Name;
+            public string Type;
+        }
+
+        public class TealFunction
+        {
+            public string Name;
+            public string ReturnType;
+            public List<TealVariable> Parameters = new List<TealVariable>();
+        }
+
+        public class TealEnum
+        {
+            public string Name;
+            public List<string> Items = new List<string>();
+
+            public TealEnum(CppEnum parsedEnum)
+            {
+                Name = parsedEnum.Name;
+                Items = parsedEnum.Items.Select(item => item.Name).ToList();
+            }
+        }
+
+        public class TealClass
+        {
+            public string Name;
+            public List<TealFunction> Constructors = new List<TealFunction>();
+            public List<TealFunction> Functions = new List<TealFunction>();
+            public List<TealVariable> Fields = new List<TealVariable>();
+            public CppTypedef Specialization;
+
+            public TealClass(CppClass cppClass, CppTypedef specialization = null)
+            {
+                Name = specialization != null ? specialization.Name : cppClass.Name;
+                Specialization = specialization;
+                addClass(cppClass);
+            }
+
+            public void addClass(CppClass cppClass)
+            {
+                foreach (CppBaseType baseType in cppClass.BaseTypes)
+                {
+                    if (baseType.Type.TypeKind == CppTypeKind.StructOrClass || baseType.Type.TypeKind == CppTypeKind.Typedef)
+                    {
+                        addClass(baseType.Type as CppClass);
+                    }
+                }
+
+                if (!cppClass.Attributes.Where(x => x.Name == "LUA_USERTYPE_NO_CTOR").Any())
+                {
+                    Constructors.AddRange(cppClass.Constructors
+                        .Where(func => func.IsConstructor())
+                        .Select(func => new TealFunction
+                        {
+                            Name = "new",
+                            ReturnType = Name,
+                            Parameters = func.Parameters.Select(param => new TealVariable { Name = param.GetTealName(), Type = param.Type.ConvertToTealType(Specialization) }).ToList()
+                        }));
+                }
+
+                Fields.AddRange(cppClass.Fields
+                    .Where(field => field.IsNormalVar() || field.IsReadOnly())
+                    .Select(field => new TealVariable { Name = field.Name, Type = field.Type.ConvertToTealType(Specialization) }).ToList());
+
+                Functions.AddRange(cppClass.Functions
+                    .Where(func => func.IsNormalFunc() || func.IsOverloadFunc())
+                    .Select(func => new TealFunction
+                    {
+                        Name = func.Name,
+                        ReturnType = func.ReturnType.ConvertToTealType(Specialization),
+                        Parameters = func.Parameters.Select(param => new TealVariable { Name = param.GetTealName(), Type = param.Type.ConvertToTealType(Specialization) }).ToList()
+                    }));
+            }
+        }
+
+        public class TealNamespace
+        {
+            public string Name;
+            public List<TealFunction> Functions = new List<TealFunction>();
+
+            public TealNamespace(LuaUserType userType)
+            {
+                Name = userType.TypeNameLower;
+
+                Functions.AddRange((userType.OriginalElement as CppNamespace).Functions
+                .Where(func => func.IsNormalFunc() || func.IsOverloadFunc())
+                .Select(func => new TealFunction
+                {
+                    Name = func.Name,
+                    ReturnType = func.ReturnType.ConvertToTealType(),
+                    Parameters = func.Parameters.Select(param => new TealVariable { Name = param.GetTealName(), Type = param.Type.ConvertToTealType() }).ToList()
+                }));
+            }
+        }
+
+        public TealCodeGenWriter(CppCompilation compilation, string scrib) : base(compilation, scrib)
+        { }
+
+
+
+        protected override string GetContentFromLuaUserFile(LuaUserTypeFile value, string fileName, bool isGame)
+        {
+            LinkedList<TealClass> classes = new LinkedList<TealClass>();
+            LinkedList<TealEnum> enums = new LinkedList<TealEnum>();
+            LinkedList<TealNamespace> namespaces = new LinkedList<TealNamespace>();
+
+            bool FindSpecializationInNamespace(CppClass cppClass, CppNamespace cppNamespace, string specialization)
+            {
+                foreach (var cppTypedef in cppNamespace.Typedefs)
+                {
+                    if (cppTypedef.Name == specialization)
+                    {
+                        classes.AddLast(new TealClass(cppClass, cppTypedef as CppTypedef));
+                        return true;
+                    }
+                }
+                foreach (var innerNamespace in cppNamespace.Namespaces)
+                {
+                    if (FindSpecializationInNamespace(cppClass, innerNamespace, specialization))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            foreach (var lu in value.userTypes.Values)
+            {
+                if (lu.IsClass)
+                {
+                    foreach (var cppClass in lu.Classes)
+                    {
+                        var isTemplated = cppClass.Attributes.Where(x => x.Name == "LUA_USERTYPE_TEMPLATE");
+                        if (isTemplated.Any())
+                        {
+                            foreach (string specialization in isTemplated.First().Arguments.Split(','))
+                            {
+                                FindSpecializationInNamespace(cppClass, rootNamespace, specialization);
+                            }
+                        }
+                        else
+                        {
+                            classes.AddLast(new TealClass(cppClass));
+                        }
+                    }
+                }
+                else if (lu.IsNamespace)
+                {
+                    namespaces.AddLast(new TealNamespace(lu));
+                }
+                foreach (var parsedEnum in lu.Enums)
+                {
+                    enums.AddLast(new TealEnum(parsedEnum));
+                }
+            }
+
+            var scribe = Template.Parse(File.ReadAllText(template));
+            return scribe.Render(new { Classes = classes, Enums = enums, Namespaces = namespaces });
+        }
+
+        protected override string GetUsertypeFileName(string usertypeFile)
+        {
+            return $"{Path.GetFileNameWithoutExtension(usertypeFile).FirstCharToUpper()}.d.tl";
+        }
+
+        protected override void WriteAllFiles(string v, bool isGame)
+        {
+            base.WriteAllFiles(v, isGame);
+
+            // TODO(jmcmorris): We need proper topological sorting of the usertype files so that dependencies are loaded first
+    //        var newFileName = "..\\..\\tlconfig.lua";
+    //        var newPath = Path.Combine(v, newFileName);
+    //        string content = @"return {
+    //include_dir = {
+    //    'src\\teal\\',
+    //},
+    //preload_modules = {";
+
+    //        content += string.Join(",", userTypeFiles.Select(usertypeFile => $"\n    '{Path.GetFileNameWithoutExtension(usertypeFile.Key).FirstCharToUpper()}'"));
+    //        content += "\n    }\n}\n";
+    //        WriteFileContent(content, newPath);
+        }
+
+
+    }
+}


### PR DESCRIPTION
Refactored code and added in support to expose c++ code as Teal declaration files, `.d.tl`.

Overall I think the code is pretty good but `ConvertToTealType` did get messy towards the end when trying to handle templates and typedefs. This is mostly because cppAST is missing some data such as `Vec2<int, 16>` is trimmed down to just Vec2<int>.

Another blemish is that tlconfig.lua needs to order preloaded modules by dependencies which is a huge can of worms. Maybe it is worth getting this to work but I'm not sure about it as I believe it'll require some substantial changes to determine the dependencies.