### PR TITLE
A few things. Command Line argument clairty, missing template files. submodule URL changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Ext/CppAst"]
 	path = Ext/CppAst
-	url = git@github.com:wackoisgod/CppAst.git
+	url = https://github.com/wackoisgod/CppAst.git
 	branch = ext_projects 

--- a/CodeGenWriter.cs
+++ b/CodeGenWriter.cs
@@ -46,16 +46,18 @@ namespace LuaExpose
         }
 
         protected string template;
+        protected string generatedNamespace;
         protected CppNamespace rootNamespace;
         protected CppCompilation compiledCode;
         protected Dictionary<string, LuaUserTypeFile> userTypeFiles;
         protected string userTypeFilePattern;
         protected List<string> preservedFiles = new List<string>();
 
-        public CodeGenWriter(CppCompilation compilation, string scrib)
+        public CodeGenWriter(CppCompilation compilation, string scrib, string rootNS)
         {
             template = scrib;
-            rootNamespace = compilation.Namespaces.Where(x => x.Name.Contains("siege")).FirstOrDefault();
+            generatedNamespace = rootNS;
+            rootNamespace = compilation.Namespaces.Where(x => x.Name.Contains(rootNS)).FirstOrDefault();
             compiledCode = compilation;
             userTypeFiles = new Dictionary<string, LuaUserTypeFile>();
         }

--- a/Extras/luascript_template.txt
+++ b/Extras/luascript_template.txt
@@ -2,7 +2,7 @@
 {{ end }}
 #include <sol/sol.hpp>
 
-namespace siege { 
+namespace {{ namespace }} { 
     void lua_expose_usertypes_{{ltype}}(sol::state_state& state) {
         {{ for us in usings }}{{ us }}
         {{ end }}

--- a/Extras/luascript_template.txt
+++ b/Extras/luascript_template.txt
@@ -3,7 +3,7 @@
 #include <sol/sol.hpp>
 
 namespace {{ namespace }} { 
-    void lua_expose_usertypes_{{ltype}}(sol::state_state& state) {
+    void lua_expose_usertypes_{{ltype}}(sol::state_view& state) {
         {{ for us in usings }}{{ us }}
         {{ end }}
         {{ for c in classes }}{{ c }}

--- a/Extras/tstl_template.txt
+++ b/Extras/tstl_template.txt
@@ -1,0 +1,43 @@
+declare global {
+    {{~ for enum in enums ~}}
+    enum {{ enum.name }} {
+        {{~ for item in enum.items ~}}
+        {{ item }},
+        {{~ end ~}}
+    }
+
+    {{~ end ~}}
+    {{~ for class in classes ~}}
+    {{~ if class.has_constructors ~}}    /** @customConstructor {{ class.name }}.new */{{end}}
+    class {{ class.name }} {
+        {{~ for ctor in class.constructors ~}}
+        {{ if ctor.is_private }}private {{end}}constructor({{ for param in ctor.parameters }}{{param.name}}: {{param.type}}{{if !for.last }}, {{ end }}{{ end }}){{if ctor.return_type != ""}}{{end}};
+        {{~ end ~}}
+        {{~ for f in class.functions ~}}
+        {{ if f.is_private }}private {{end}}{{ if f.is_static }}static {{end}}{{ f.name }}{{if f.has_generics}}<{{for generic in f.generics}}{{generic}}{{if !for.last }}, {{ end }}{{ end }}>{{ end }}({{ for param in f.parameters }}{{param.name}}: {{param.type}}{{if !for.last }}, {{ end }}{{ end }}){{ if f.return_type != "" }}: {{f.return_type}}{{ end }};
+        {{~ end ~}}
+        {{~ for field in class.fields ~}}
+        {{if field.is_static}}static {{ end}}{{ field.name }}: {{ field.type }};
+        {{~ end ~}}
+    }
+
+    {{~ end ~}}
+    {{~ for namespace in namespaces ~}}
+    /** @noSelf **/
+    namespace {{ namespace.name }} {
+        {{~ for f in namespace.functions ~}}
+        function {{ f.name }}{{if f.has_generics}}<{{for generic in f.generics}}{{generic}}{{if !for.last }}, {{ end }}{{ end }}>{{ end }}({{ for param in f.parameters }}{{param.name}}: {{param.type}}{{if !for.last }}, {{ end }}{{ end }}){{ if f.return_type != "" }}: {{f.return_type}}{{ end }};
+        {{~ end ~}}
+    }
+
+    {{~ end ~}}
+    {{~ for f in globals.functions ~}}
+    function {{ f.name }}{{if f.has_generics}}<{{for generic in f.generics}}{{generic}}{{if !for.last }}, {{ end }}{{ end }}>{{ end }}({{ for param in f.parameters }}{{param.name}}: {{param.type}}{{if !for.last }}, {{ end }}{{ end }}){{ if f.return_type != "" }}: {{f.return_type}}{{ end }};
+    {{~ end ~}}
+
+    {{~ for field in globals.fields ~}}
+    const {{ field.name }}: {{ field.type }};
+    {{~ end ~}}
+}
+
+export {}

--- a/LuaCodeGenWriter.cs
+++ b/LuaCodeGenWriter.cs
@@ -680,7 +680,6 @@ namespace LuaExpose
             ConcurrentQueue<string> includeFiles = new ConcurrentQueue<string>(isGame ? globalGameHeaders : globalHeaders);
             List<string> usings = new List<string>();
 
-            string rootNS = generatedNamespace;
             LinkedList<string> namespaces = new LinkedList<string>();
             LinkedList<string> classes = new LinkedList<string>();
             LinkedList<string> enums = new LinkedList<string>();
@@ -689,8 +688,8 @@ namespace LuaExpose
             value.userTypes.AsParallel().ForAll(x =>
             {
                 var p = Path.GetFullPath(x.Value.OriginLocation);
-                int s = p.LastIndexOf("siege");
-                int offset = 6;
+                int s = p.LastIndexOf(generatedNamespace);
+                int offset = generatedNamespace.Length + 1;
                 if (isGame)
                 {
                     s = p.LastIndexOf("src");
@@ -772,7 +771,7 @@ namespace LuaExpose
             }
 
             var scribe = Template.Parse(File.ReadAllText(template));
-            return scribe.Render(new { Includes = includes.Distinct(), Namespace = rootNS, Ltype = fileName.FirstCharToUpper(), Namespaces = namespaces, Classes = classes, Enums = enums, Usings = usings});
+            return scribe.Render(new { Includes = includes.Distinct(), Namespace = generatedNamespace, Ltype = fileName.FirstCharToUpper(), Namespaces = namespaces, Classes = classes, Enums = enums, Usings = usings});
         }
 
         protected override string GetUsertypeFileName(string usertypeFile)

--- a/LuaCppAstHelpers.cs
+++ b/LuaCppAstHelpers.cs
@@ -348,6 +348,11 @@ namespace LuaExpose
                             name = ((input as CppUnexposedType).TemplateParameters[0] as CppUnexposedType).Name;
                         }
 
+                        int index = name.LastIndexOf("::");
+                        if (index != -1)
+                            name = name.Substring(index + 2);
+                        name = name.Replace("&&", "");
+
                         if (TypeMappings.ContainsKey(name))
                         {
                             return TypeMappings[name];

--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,8 @@ namespace LuaExpose
     {
         public class Options
         {
-           
+            [Option('n', "namespace", Required = true, HelpText = "Root namespace")]
+            public string RootNamespace { get; set; }
             [Option('r', "root", Required = true, HelpText = "Root Source Dir")]
             public string RootSource { get; set; }
 
@@ -194,7 +195,7 @@ namespace LuaExpose
                 Stopwatch localWatch = new Stopwatch();
                 localWatch.Start();
                 Console.WriteLine("Running LuaCodeGenWriter");
-                var lua = new LuaCodeGenWriter(compilation, opts.Scrib);
+                var lua = new LuaCodeGenWriter(compilation, opts.Scrib, opts.RootNamespace);
                 lua.Run(opts.Output, opts.IsGame);
                 WriteWatch(localWatch, "LuaCodeGenWriter Runtime: ");
             }
@@ -203,7 +204,7 @@ namespace LuaExpose
                 Stopwatch localWatch = new Stopwatch();
                 localWatch.Start();
                 Console.WriteLine("Running TypeScriptCodeGenWriter");
-                var lua = new TypeScriptCodeGenWriter(compilation, opts.TypeScriptScrib);
+                var lua = new TypeScriptCodeGenWriter(compilation, opts.TypeScriptScrib, opts.RootNamespace);
                 lua.Run(opts.Declarations, opts.IsGame);
                 WriteWatch(localWatch, "TypeScriptCodeGenWriter Runtime: ");
             }

--- a/Program.cs
+++ b/Program.cs
@@ -32,30 +32,31 @@ namespace LuaExpose
     {
         public class Options
         {
+           
             [Option('r', "root", Required = true, HelpText = "Root Source Dir")]
             public string RootSource { get; set; }
 
-            [Option('s', "siege", Required = true, HelpText = "Siege Source Dir")]
-            public string SiegeSource { get; set; }
+            [Option('i', "input", Required = true, HelpText = "Directory containing source code to expose to Lua")]
+            public string InputDirectory { get; set; }
 
-            [Option('o', "output", Required = true, HelpText = "Siege Source Dir")]
+            [Option('o', "output", Required = true, HelpText = "Directory where this tool should place its generated code")]
             public string Output { get; set; }
 
-            [Option('l', "lib", Required = true, HelpText = "Siege Source Dir")]
+            [Option('l', "lib", Required = true, HelpText = "Directory containing external library code")]
             public string libs { get; set; }
 
             [Option('t', "temp", Required = true, HelpText = "Lua Output Template")]
             public string Scrib { get; set; }
 
-            [Option('g', "game", Required = false, HelpText = "Siege Source Dir")]
+            [Option('g', "game", Required = false, HelpText = "Specifies whether this generation is done in the context of a Siege game")]
             public bool IsGame { get; set; }
 
-            [Option('c', "cpp", Required = false, HelpText = "Siege Source Dir")]
+            [Option('c', "cpp", Required = false, HelpText = "C++ version to use in generating C++ code")]
             public string CppVersion { get; set; }
 
-            [Option('O', "tsoutput", Required = true, HelpText = "TypeScript Declaration Output")]
+            [Option('O', "tsoutput", Required = false, HelpText = "TypeScript Declaration Output")]
             public string Declarations { get; set; }
-            [Option('T', "tstemp", Required = true, HelpText = "TypeScript Output Template")]
+            [Option('T', "tstemp", Required = false, HelpText = "TypeScript Output Template")]
             public string TypeScriptScrib { get; set; }
         }
 
@@ -99,9 +100,9 @@ namespace LuaExpose
             p.AdditionalArguments.Add("-Wno-unknown-attributes");
             p.IncludeFolders.Add(opts.RootSource);
             if (!opts.IsGame)
-                p.IncludeFolders.Add(opts.SiegeSource);
+                p.IncludeFolders.Add(opts.InputDirectory);
             else
-                p.SystemIncludeFolders.Add(opts.SiegeSource);
+                p.SystemIncludeFolders.Add(opts.InputDirectory);
             p.SystemIncludeFolders.Add($"{opts.libs}/SDL2/include");
             p.SystemIncludeFolders.Add($"{opts.libs}/parallel_hashmap/include");
             p.SystemIncludeFolders.Add($"{opts.libs}/bgfx/include");
@@ -149,7 +150,7 @@ namespace LuaExpose
                 p.SystemIncludeFolders.Add($"{opts.libs}/bgfx/include/compat/msvc");
             }
             
-            p.SystemIncludeFolders.Add($"{opts.SiegeSource}/external");
+            p.SystemIncludeFolders.Add($"{opts.InputDirectory}/external");
 
 
             //var actualFiles = f.Where(x =>

--- a/TypeScriptCodeGenWriter.cs
+++ b/TypeScriptCodeGenWriter.cs
@@ -207,7 +207,7 @@ namespace LuaExpose
             }
         }
 
-        public TypeScriptCodeGenWriter(CppCompilation compilation, string scrib) : base(compilation, scrib)
+        public TypeScriptCodeGenWriter(CppCompilation compilation, string scrib, string rootNS) : base(compilation, scrib, rootNS)
         {
             userTypeFilePattern = "*.d.ts";
         }


### PR DESCRIPTION
So I added (or changed):

- Better descriptions for the command line arguments.
- Change the URL for the CppAst submodule, because it used an SSH URL, where the HTTPS one would be easier.
- The missing Typescript template
- A new CLI parameter that lets you set the namespace that the generated C++ code is in